### PR TITLE
PhoneRadio formatter & minsdk

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -4,7 +4,7 @@
     android:versionName="1.0" >
 
     <uses-sdk
-        android:minSdkVersion="9"
+        android:minSdkVersion="10"
         android:targetSdkVersion="19" />
 
     <!-- Required to store data on device (policy: store only/transfer periodically) -->

--- a/src/com/ubhave/dataformatter/DataFormatter.java
+++ b/src/com/ubhave/dataformatter/DataFormatter.java
@@ -18,6 +18,7 @@ import com.ubhave.dataformatter.json.pull.MagneticFieldFormatter;
 import com.ubhave.dataformatter.json.pull.MicrophoneFormatter;
 import com.ubhave.dataformatter.json.pull.SmsContentReaderFormatter;
 import com.ubhave.dataformatter.json.pull.WifiFormatter;
+import com.ubhave.dataformatter.json.pull.PhoneRadioFormatter;
 import com.ubhave.dataformatter.json.push.BatteryFormatter;
 import com.ubhave.dataformatter.json.push.ConnectionStateFormatter;
 import com.ubhave.dataformatter.json.push.ConnectionStrengthFormatter;
@@ -83,6 +84,8 @@ public abstract class DataFormatter
 			return new PressureFormatter(c);
 		case SensorUtils.SENSOR_TYPE_MAGNETIC_FIELD:
 			return new MagneticFieldFormatter(c);
+		case SensorUtils.SENSOR_TYPE_PHONE_RADIO:
+            return new PhoneRadioFormatter(c);
 		default:
 			return null;
 		}


### PR DESCRIPTION
While doing own implemetation of logger using your libary I found that : 
-- min sdk version must be 10 because of compatibillity issues with other projects such as SensorManager (min.sdk 10)

-- PHONE_RADIO sensor type missing in switch (DataFormatter.java), which resulting NullException during formating PhoneRadio data to JSONObject.

These things I fixed in my project, so I wanted to let you know about it because of cool libary you made.